### PR TITLE
Add PlatformIO build test to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,13 @@ repos:
         args: [--style=file]
       - id: cpplint
         args: [--filter=-legal/copyright,-whitespace/tab]
+
+  - repo: local
+    hooks:
+      - id: platformio-build
+        name: PlatformIO Build Test
+        entry: uv run task build
+        language: system
+        pass_filenames: false
+        files: \.(cpp|c|h|hpp|ino)$|platformio\.ini$
+        description: Run PlatformIO build to ensure code compiles


### PR DESCRIPTION
## Summary
- Add automated build test to pre-commit hooks
- Prevents broken code from being committed
- Integrates with existing uv/taskipy setup

## Changes
- Added local pre-commit hook that runs `uv run task build`
- Hook triggers on C/C++ source files and platformio.ini changes
- Build must succeed for commit to proceed

## Test plan
- [x] Verify pre-commit hook configuration is valid
- [x] Test that build runs when modifying .cpp files
- [x] Test that build runs when modifying platformio.ini
- [x] Confirm commit is blocked if build fails

🤖 Generated with [Claude Code](https://claude.ai/code)